### PR TITLE
Use enums for stats and battle state

### DIFF
--- a/scripts/BattleManager.gd
+++ b/scripts/BattleManager.gd
@@ -6,7 +6,8 @@ class_name BattleManager
 # --- State ---
 var combatants: Array = []           # All entities participating in combat
 var action_queue: Array = []         # Queue of pending combat actions
-var is_processing_action: bool = false
+enum State { IDLE, PROCESSING }
+var state: State = State.IDLE
 
 # Called when the scene is ready
 func _ready() -> void:
@@ -24,8 +25,8 @@ func _ready() -> void:
 
 # Called every frame to manage combat flow
 func _process(delta: float) -> void:
-	if is_processing_action:
-		return
+        if state == State.PROCESSING:
+                return
 
 	for entity in combatants:
 		if entity.is_alive:
@@ -38,11 +39,11 @@ func _process(delta: float) -> void:
 					queue_action(action)
 					entity.reset_ct()
 
-	if action_queue.size() > 0:
-		var action = action_queue.pop_front()
-		is_processing_action = true
-		action.execute()
-		is_processing_action = false
+        if action_queue.size() > 0:
+                var action = action_queue.pop_front()
+                state = State.PROCESSING
+                action.execute()
+                state = State.IDLE
 
 # Adds a new action to the queue
 func queue_action(action: CombatAction) -> void:

--- a/scripts/CombatEntity.gd
+++ b/scripts/CombatEntity.gd
@@ -1,20 +1,32 @@
 extends Node2D
 class_name CombatEntity
 
+# Enumeration for accessing stat dictionary keys
+enum Stat {
+    HP,
+    MAX_HP,
+    MP,
+    MAX_MP,
+    STRENGTH,
+    MAGIC,
+    SPEED,
+    VITALITY
+}
+
 # Base class for all combat participants (players and enemies)
 
 # --- Identity & Vital Stats ---
 var display_name: String = "Unnamed"
 var level: int = 1
 var stats: Dictionary = {
-	"hp": 100,
-	"max_hp": 100,
-	"mp": 0,
-	"max_mp": 0,
-	"strength": 10,
-	"magic": 10,
-	"speed": 10,
-	"vitality": 10
+        Stat.HP: 100,
+        Stat.MAX_HP: 100,
+        Stat.MP: 0,
+        Stat.MAX_MP: 0,
+        Stat.STRENGTH: 10,
+        Stat.MAGIC: 10,
+        Stat.SPEED: 10,
+        Stat.VITALITY: 10
 }
 
 # --- Equipment ---
@@ -32,7 +44,7 @@ func update_ct(delta: float) -> void:
 	if not is_alive:
 		return
 
-	var speed = stats.get("speed", 10)
+        var speed = stats.get(Stat.SPEED, 10)
 	ct += delta * speed
 
 	if ct >= 100.0:
@@ -46,9 +58,9 @@ func reset_ct() -> void:
 
 # Applies damage to this entity
 func take_damage(amount: float) -> void:
-	stats["hp"] -= amount
-	if stats["hp"] <= 0:
-		stats["hp"] = 0
+        stats[Stat.HP] -= amount
+        if stats[Stat.HP] <= 0:
+                stats[Stat.HP] = 0
 		is_alive = false
 		# TODO: Handle death animation or removal if needed
 		
@@ -66,7 +78,7 @@ func perform_attack(target: CombatEntity) -> void:
 
 	while true:
 		var weapon_power = weapon.power
-		var base = (weapon_power * (stats.get("strength", 10) + level)) / 2.0
+                var base = (weapon_power * (stats.get(Stat.STRENGTH, 10) + level)) / 2.0
 		var variance = randf_range(1.0, 1.125)
 		var damage = base * variance
 

--- a/scripts/Enemy.gd
+++ b/scripts/Enemy.gd
@@ -9,16 +9,16 @@ func _ready() -> void:
 	level = 10
 
 	# Example stats — override per enemy type or prefab
-	stats = {
-		"hp": 300,
-		"max_hp": 300,
-		"mp": 0,
-		"max_mp": 0,
-		"strength": 16,
-		"magic": 8,
-		"speed": 12,
-		"vitality": 8
-	}
+        stats = {
+                CombatEntity.Stat.HP: 300,
+                CombatEntity.Stat.MAX_HP: 300,
+                CombatEntity.Stat.MP: 0,
+                CombatEntity.Stat.MAX_MP: 0,
+                CombatEntity.Stat.STRENGTH: 16,
+                CombatEntity.Stat.MAGIC: 8,
+                CombatEntity.Stat.SPEED: 12,
+                CombatEntity.Stat.VITALITY: 8
+        }
 
 	# Equip a weapon (adjust per enemy)
 	weapon = preload("res://data/Weapon_Broadsword.tres")
@@ -27,6 +27,6 @@ func _ready() -> void:
 
 func _process(delta: float) -> void:
 	# Simple real-time HP bar update
-	var hp_bar = get_node("HPBar")
-	hp_bar.max_value = stats["max_hp"]
-	hp_bar.value = stats["hp"]
+        var hp_bar = get_node("HPBar")
+        hp_bar.max_value = stats[CombatEntity.Stat.MAX_HP]
+        hp_bar.value = stats[CombatEntity.Stat.HP]

--- a/scripts/PlayerCharacter.gd
+++ b/scripts/PlayerCharacter.gd
@@ -9,16 +9,16 @@ func _ready() -> void:
 	level = 12
 
 	# Player stats — adjust per character
-	stats = {
-		"hp": 450,
-		"max_hp": 450,
-		"mp": 30,
-		"max_mp": 30,
-		"strength": 24,
-		"magic": 12,
-		"speed": 18,
-		"vitality": 10
-	}
+        stats = {
+                CombatEntity.Stat.HP: 450,
+                CombatEntity.Stat.MAX_HP: 450,
+                CombatEntity.Stat.MP: 30,
+                CombatEntity.Stat.MAX_MP: 30,
+                CombatEntity.Stat.STRENGTH: 24,
+                CombatEntity.Stat.MAGIC: 12,
+                CombatEntity.Stat.SPEED: 18,
+                CombatEntity.Stat.VITALITY: 10
+        }
 
 	# Initial equipment (can later be swapped via UI or inventory system)
 	weapon = preload("res://data/Weapon_Broadsword.tres")
@@ -27,6 +27,6 @@ func _ready() -> void:
 
 func _process(delta: float) -> void:
 	# Simple real-time HP bar update
-	var hp_bar = get_node("HPBar")
-	hp_bar.max_value = stats["max_hp"]
-	hp_bar.value = stats["hp"]
+        var hp_bar = get_node("HPBar")
+        hp_bar.max_value = stats[CombatEntity.Stat.MAX_HP]
+        hp_bar.value = stats[CombatEntity.Stat.HP]


### PR DESCRIPTION
## Summary
- define `Stat` enum in `CombatEntity`
- refactor entity scripts to use the enum keys
- add `State` enum in `BattleManager` for processing state

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840decd73d8832eae570de1dc53134a