### PR TITLE
Remove UI battle log

### DIFF
--- a/scenes/BattleScene.tscn
+++ b/scenes/BattleScene.tscn
@@ -15,18 +15,3 @@ position = Vector2(339, 104)
 [node name="BattleManager" type="Node" parent="."]
 script = ExtResource("3_ftvu5")
 
-[node name="ActionLog" type="VBoxContainer" parent="."]
-anchors_preset = 2
-anchor_top = 1.0
-anchor_bottom = 1.0
-offset_left = 12.0
-offset_top = 203.0
-offset_right = 593.0
-offset_bottom = 636.0
-grow_vertical = 0
-size_flags_horizontal = 3
-
-[node name="LogTemplate" type="Label" parent="ActionLog"]
-visible = false
-layout_mode = 2
-text = "..."

--- a/scripts/BattleManager.gd
+++ b/scripts/BattleManager.gd
@@ -20,11 +20,6 @@ func _ready() -> void:
 
 		combatants = [player, enemy]      # Order is not important in this demo
 
-		# Announce the start of battle in the on-screen log
-		log_action("Battle started between %s and %s" % [
-				player.display_name,
-				enemy.display_name
-		])
 
 # Called every frame to update CT gauges and perform actions when ready
 func _process(delta: float) -> void:
@@ -63,20 +58,3 @@ func get_random_enemy_for(source: CombatEntity) -> CombatEntity:
 						return entity
 		return null
 
-# Adds a labelled message to the UI element named "ActionLog"
-func log_action(text: String) -> void:
-	var log_box = get_tree().get_current_scene().get_node("ActionLog")
-	if not log_box:
-		return
-
-	var template = log_box.get_node("LogTemplate")
-	if not template:
-		return
-
-		var new_entry = template.duplicate()
-		new_entry.text = text
-		new_entry.visible = true
-
-		log_box.add_child(new_entry)
-		# Insert above the template so the newest entry appears last
-		log_box.move_child(new_entry, log_box.get_child_count() - 2)

--- a/scripts/CombatEntity.gd
+++ b/scripts/CombatEntity.gd
@@ -67,10 +67,6 @@ func take_damage(amount: float) -> void:
 		is_alive = false
 		# TODO: Handle death animation or removal if needed
 		
-		# Log death to battle log
-		var battle_manager = get_tree().get_current_scene().get_node("BattleManager")
-		if battle_manager and battle_manager.has_method("log_action"):
-			battle_manager.log_action("%s has fallen!" % display_name)
 			
 # Calculates damage and applies it to the target. May chain multiple hits
 func perform_attack(target: CombatEntity) -> void:
@@ -93,18 +89,6 @@ func perform_attack(target: CombatEntity) -> void:
 
 		target.take_damage(damage)
 
-		# Write the attack summary to the battle log
-		var log_text = "%s hits %s for %d%s (Hit %d)" % [
-			display_name,
-			target.display_name,
-			damage,
-			" CRITICAL!" if is_crit else "",
-			combo_count
-			]
-
-		var battle_manager = get_tree().get_current_scene().get_node("BattleManager")
-		if battle_manager and battle_manager.has_method("log_action"):
-			battle_manager.log_action(log_text)
 
 		if not target.is_alive:
 			break


### PR DESCRIPTION
## Summary
- strip out log functionality from combat entities and manager
- remove ActionLog node from the battle scene

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684196490108832eb916a82759036de4