### PR TITLE
Add defeat notification

### DIFF
--- a/scripts/CombatEntity.gd
+++ b/scripts/CombatEntity.gd
@@ -96,11 +96,11 @@ func perform_attack(target: CombatEntity) -> void:
 		if is_crit:
 			msg += ", critical"
 		msg += ")"
-		print(msg)
+                print(msg)
 
-
-		if not target.is_alive:
-			break
+                if not target.is_alive:
+                        print("%s defeated %s!" % [display_name, target.display_name])
+                        break
 
 		# Combo continuation check
 		# Random chance to keep attacking with the same weapon


### PR DESCRIPTION
## Summary
- display a message when an entity kills another combatant

## Testing
- `godot` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68423c8eadd0832ea58e770f60e7a751