### PR TITLE
Add WeaponType enum

### DIFF
--- a/data/Weapon.gd
+++ b/data/Weapon.gd
@@ -4,7 +4,32 @@ class_name Weapon
 # Represents a weapon resource that can be equipped by a combatant
 # Influences damage, critical hits, and combo chance
 
+# Enumeration of the possible weapon categories. These will later control
+# which damage formula gets used for an attack.
+enum WeaponType {
+                UNARMED,
+                ONE_HANDED_SWORD,
+                TWO_HANDED_SWORD,
+                SPEAR,
+                CROSSBOW,
+                ROD,
+                POLE,
+                MACE,
+                KATANA,
+                STAVE,
+                AXE,
+                HAMMER,
+                HAND_BOMB,
+                DAGGER,
+                NINJA_SWORD,
+                BOW,
+                GUN,
+                MEASURE
+                }
+
 @export var name: String = "Basic Sword"    # Display name
+
+@export var weapon_type: WeaponType = WeaponType.ONE_HANDED_SWORD  # Category of the weapon
 
 @export var power: float = 10.0           # Base weapon power used in attack formulas
 @export var crit_chance: float = 0.05     # Chance to land a critical hit (e.g. 5%)

--- a/data/Weapon_Broadsword.tres
+++ b/data/Weapon_Broadsword.tres
@@ -9,4 +9,5 @@ power = 10.0
 crit_chance = 0.05
 crit_multiplier = 1.5
 combo_chance = 0.1
+weapon_type = 1
 metadata/_custom_type_script = "uid://cyn5f511n1ote"

--- a/data/Weapon_Claws.tres
+++ b/data/Weapon_Claws.tres
@@ -9,4 +9,5 @@ power = 18
 combo_chance = 0.1
 crit_chance = 0.1
 crit_multiplier = 1.4
+weapon_type = 0
 metadata/_custom_type_script = "uid://cyn5f511n1ote"


### PR DESCRIPTION
## Summary
- add `WeaponType` enum to `Weapon.gd`
- export `weapon_type` on Weapon resources
- set the type on Broadsword and Claws weapon definitions

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6842ede9a9a8832eb1aa36db256cdc9c